### PR TITLE
Bump Setup Typst to v4

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,10 +25,10 @@ jobs:
           cp SourceHanSansTW/SubsetOTF/TW/*.otf /usr/share/fonts/
           fc-cache -fv
       - name: Setup Typst
-        uses: yusancky/setup-typst@v2
+        uses: typst-community/setup-typst@v4
         id: setup-typst
         with:
-          version: 'latest'
+          typst-version: 'latest'
       - name: Print supported fonts
         run: typst fonts
       - name: Build resume
@@ -36,7 +36,7 @@ jobs:
           touch secrets.toml
           typst compile resume.typ
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Resume-PDF
           path: resume.pdf
@@ -55,7 +55,7 @@ jobs:
       - name: Render resume as PNG
         run: pdftoppm resume.pdf resume -png -r 300
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Resume-PNG
           path: '*.png'


### PR DESCRIPTION
Bump [`typst-community/setup-typst`](https://github.com/typst-community/setup-typst) to v4

> [!IMPORTANT] 
> The action `yusancky/setup-typst` has officially been migrated to repository `typst-community/setup-typst`. See [announcement](https://gist.github.com/yusancky/b676f56d40d6346dfc67ed477ca2ea1a) for more information.